### PR TITLE
Fix timeout issue with proxy [#7]

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,11 +8,6 @@
     name: "{{ python_pip_packages }}"
     state: present
 
-- name: update pip
-  pip:
-    name: pip
-    state: latest  # noqa 403 The latest version of pip is required.
-
 - name: set pip alternatives
   alternatives:
     name: pip
@@ -39,6 +34,11 @@
     mode: "0644"
   when:
     - python_pip_trusted_host is defined
+
+- name: update pip
+  pip:
+    name: pip
+    state: latest  # noqa 403 The latest version of pip is required.
 
 - name: install requested modules
   pip:


### PR DESCRIPTION
Fix an issue where the role times-out when the managed node is
behind a proxy (https://github.com/robertdebock/ansible-role-python_pip/issues/7).

---
name: Rohan Krishnadev
about: Fix an issue where the role times-out when the managed node is
behind a proxy

---

**Describe the change**
Refactor task list to ensure that pip update is run after proxy has been set.

**Testing**
I haven't added any tests as I have not added any new feature. 
All the existing tests pass locally and the role was run successfully on an 
environment where the managed hosts are behind a proxy.